### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/mdpow/fep.py
+++ b/mdpow/fep.py
@@ -650,13 +650,14 @@ class Gsolv(Journalled):
         kwargs.update(self.schedules[component].mdp_dict)  # sets soft core & lambda0/1 state
         
         # for BAR
-        if feps is not None: # feps is only passed as an argument if BAR is desired method, defaults to TI otherwise
-            if feps[0]isNone:
+        if feps is not None: 
+            # feps is only passed as an argument if BAR is desired method, defaults to TI otherwise
+            if feps[0] is None:
                 feplambdas = feps[1]
-            elif feps[1]isNone:
+            elif feps[1] is None:
                 feplambdas = feps[0]
             else:
-                feplambdas = "{0} {1}".format(feps[0],feps[1])
+                feplambdas = "{0} {1}".format(feps[0], feps[1])
             
             kwargs.update(dirname=wdir, struct=self.struct, top=self.top,
                           mdp=self.mdp,

--- a/mdpow/fep.py
+++ b/mdpow/fep.py
@@ -650,10 +650,10 @@ class Gsolv(Journalled):
         kwargs.update(self.schedules[component].mdp_dict)  # sets soft core & lambda0/1 state
         
         # for BAR
-        if feps != None: # feps is only passed as an argument if BAR is desired method, defaults to TI otherwise
-            if feps[0]==None:
+        if feps is not None: # feps is only passed as an argument if BAR is desired method, defaults to TI otherwise
+            if feps[0]isNone:
                 feplambdas = feps[1]
-            elif feps[1]==None:
+            elif feps[1]isNone:
                 feplambdas = feps[0]
             else:
                 feplambdas = "{0} {1}".format(feps[0],feps[1])


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Becksteinlab:MDPOW?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:Becksteinlab:MDPOW?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)