### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/mdpow/analysis.py
+++ b/mdpow/analysis.py
@@ -342,7 +342,7 @@ class ExpComp(object):
                                 connection=experimental.connection)
 
         for num,filename in enumerate(data[1:]):
-            dbname = "logPow_computed_%d" % (num+1)
+            dbname = "logPow_computed_{0:d}".format((num+1))
             compute2 = ComputedData(filename=filename,
                                     name=dbname,
                                     connection=experimental.connection)  # add to experimental db
@@ -357,7 +357,7 @@ class ExpComp(object):
                 if not os.path.exists(exclusions):
                     continue
                 logger.info("Loading exclusions from %(exclusions)r.", vars())
-                dbname = "exclusions_%d" % num
+                dbname = "exclusions_{0:d}".format(num)
                 excl = recsql.SQLarray_fromfile(exclusions, connection=experimental.connection, name=dbname)
                 if first_excl:
                     first_excl.merge_table(dbname)
@@ -651,7 +651,7 @@ class GsolvData(object):
         self.computed = computed  # for testing ... needs to be kept against gc :-p
 
         for num,filename in enumerate(data[1:]):
-            dbname = "energies_computed_%d" % (num+1)
+            dbname = "energies_computed_{0:d}".format((num+1))
             compute2 = ComputedData(filename=filename,
                                     name=dbname,
                                     connection=experimental.connection)  # add to experimental db
@@ -666,7 +666,7 @@ class GsolvData(object):
                 if not os.path.exists(exclusions):
                     continue
                 logger.info("Loading exclusions from %(exclusions)r.", vars())
-                dbname = "exclusions_%d" % num
+                dbname = "exclusions_{0:d}".format(num)
                 excl = recsql.SQLarray_fromfile(exclusions, connection=experimental.connection, name=dbname)
                 if first_excl:
                     first_excl.merge_table(dbname)
@@ -746,10 +746,10 @@ class GsolvData(object):
 
         mode = mode.lower()
         if not mode in ("hyd","oct"):
-            raise ValueError("mode must be either 'hyd' or 'oct', not %r" % mode)
-        fields = "CommonName, comment, ExpG%(mode)s AS ExpG, ExpG%(mode)sErr AS ExpErr, CompG%(mode)s AS CompG, CompG%(mode)sErr AS CompErr" % vars()
+            raise ValueError("mode must be either 'hyd' or 'oct', not {0!r}".format(mode))
+        fields = "CommonName, comment, ExpG{mode!s} AS ExpG, ExpG{mode!s}Err AS ExpErr, CompG{mode!s} AS CompG, CompG{mode!s}Err AS CompErr".format(**vars())
         c = self.database.SELECT(fields)
-        ExpG = "ExpG%(mode)s" % vars()
+        ExpG = "ExpG{mode!s}".format(**vars())
 
         #subplot(121)
         norm = colors.normalize(0,len(c))
@@ -773,8 +773,8 @@ class GsolvData(object):
         dy = kwargs.pop('dy', kcalmol)
         _plot_ideal(X=self.database.limits(ExpG), dy=dy, dy2=1.5*dy)
 
-        xlabel(r'experimental $\Delta G_{\rm %(mode)s}$ (kJ/mol)' % vars())
-        ylabel(r'computed $\Delta G_{\rm %(mode)s}$ (kJ/mol)' % vars())
+        xlabel(r'experimental $\Delta G_{{\rm {mode!s}}}$ (kJ/mol)'.format(**vars()))
+        ylabel(r'computed $\Delta G_{{\rm {mode!s}}}$ (kJ/mol)'.format(**vars()))
         if figname:
             savefig(figname)
             logger.info("Wrote plot to %r", figname)

--- a/mdpow/analysis/thermodynamics.py
+++ b/mdpow/analysis/thermodynamics.py
@@ -262,11 +262,11 @@ def calculate_solute_volume(solute_data, solvent_data=None,
     """
     solute_Volume = recwhere(solute_data, 'Volume')
     if len(solute_Volume) != 1:
-        errmsg = "There should only be ONE Volume entry, not %r" % solute_Volume
+        errmsg = "There should only be ONE Volume entry, not {0!r}".format(solute_Volume)
         logger.error(errmsg)
         raise ValueError(errmsg)
     if not solute_Volume.unit[0] == "nm^3":
-        errmsg = "Unit of Volume should be nm^3, not %r" % solute_Volume.unit[0]
+        errmsg = "Unit of Volume should be nm^3, not {0!r}".format(solute_Volume.unit[0])
         logger.error(errmsg)
         raise ValueError(errmsg)
     solute_Vbox = Observable(solute_data, "Volume")
@@ -307,12 +307,12 @@ def count_solvent_molecules(tpr, solvent="water"):
     # This would be MUCH easier in MDAnalysis but I don't want to add
     # this as a dependency to mdpow. g_select would also work but that's
     # more recent and also requires reading of an xvg file.
-    solventgroup = "solvent_%(solvent)s" % vars()   # should not start with a number for make_ndx!!
+    solventgroup = "solvent_{solvent!s}".format(**vars())   # should not start with a number for make_ndx!!
     try:
         cmd = ['keep 0', 'del 0', solvent_selections[solvent],
-               'name 0 %(solventgroup)s' % vars(), 'q']
+               'name 0 {solventgroup!s}'.format(**vars()), 'q']
     except KeyError:
-        raise NotImplementedError("solvent %(solvent)r not supported" % vars())
+        raise NotImplementedError("solvent {solvent!r} not supported".format(**vars()))
 
     fd, tmpndx = tempfile.mkstemp(suffix=".ndx")
     try:
@@ -320,7 +320,7 @@ def count_solvent_molecules(tpr, solvent="water"):
         rc,output,junk = gromacs.cbook.make_ndx_captured(f=tpr, o=tmpndx,
                                                          input=cmd, stderr=False)
         if rc != 0:
-            out = "\n".join(["GMX_FATAL: %s" % s for s in (junk + "\n\n" + output).split("\n")])
+            out = "\n".join(["GMX_FATAL: {0!s}".format(s) for s in (junk + "\n\n" + output).split("\n")])
             errmsg = "Failed to build index. Look at the output below for hints:\n" + out
             logger.error(errmsg)
             raise GromacsError(errmsg)
@@ -338,7 +338,7 @@ def count_solvent_molecules(tpr, solvent="water"):
             N_solvent = rec['natoms'] # == number of molecules as one atom per molecule
             break
     if N_solvent is None:
-        errmsg = "Failed to find solvent %(solvent)r in %(tpr)r" % vars()
+        errmsg = "Failed to find solvent {solvent!r} in {tpr!r}".format(**vars())
         logger.error(errmsg)
         raise ValueError(errmsg)
     logger.info("Found %(N_solvent)d %(solvent)s solvent molecules in %(tpr)r", vars())

--- a/mdpow/config.py
+++ b/mdpow/config.py
@@ -293,7 +293,7 @@ def _get_template(t):
             else:
                 _t_found = True
         if not _t_found:            # 4) nothing else to try... or introduce a PATH?
-            raise ValueError("Failed to locate the template file %(t)r." % vars())
+            raise ValueError("Failed to locate the template file {t!r}.".format(**vars()))
     return os.path.realpath(t)
 
 

--- a/mdpow/equil.py
+++ b/mdpow/equil.py
@@ -168,7 +168,7 @@ class Simulation(Journalled):
                 self.solvent = AttributeDict(itp=ITP[solvent], box=BOX[solvent],
                                              distance=DIST[solvent])
             except KeyError:
-                raise ValueError("solvent must be one of %r" % ITP.keys())
+                raise ValueError("solvent must be one of {0!r}".format(ITP.keys()))
 
             self.filename = filename or self.solvent_type+'.simulation'
 
@@ -192,7 +192,7 @@ class Simulation(Journalled):
             self.filename = filename
         with open(filename, 'wb') as f:
             cPickle.dump(self, f, protocol=cPickle.HIGHEST_PROTOCOL)
-        logger.debug("Instance pickled to %(filename)r" % vars())
+        logger.debug("Instance pickled to {filename!r}".format(**vars()))
 
     def load(self, filename=None):
         """Re-instantiate class from pickled file."""
@@ -204,7 +204,7 @@ class Simulation(Journalled):
         with open(filename, 'rb') as f:
             instance = cPickle.load(f)
         self.__dict__.update(instance.__dict__)
-        logger.debug("Instance loaded from %(filename)r" % vars())
+        logger.debug("Instance loaded from {filename!r}".format(**vars()))
 
     def make_paths_relative(self, prefix=os.path.curdir):
         """Hack to be able to copy directories around: prune basedir from paths.
@@ -302,7 +302,7 @@ class Simulation(Journalled):
         kwargs['struct'] = self._checknotempty(struct or self.files.structure, 'struct')
         kwargs['top'] = self._checknotempty(self.files.topology, 'top')
         kwargs['water'] = self.solvent.box
-        kwargs.setdefault('mainselection', '"%s"' % self.molecule)  # quotes are needed for make_ndx
+        kwargs.setdefault('mainselection', '"{0!s}"'.format(self.molecule))  # quotes are needed for make_ndx
         kwargs.setdefault('distance', self.solvent.distance)
         kwargs['includes'] = asiterable(kwargs.pop('includes',[])) + self.dirs.includes
 
@@ -369,7 +369,7 @@ class Simulation(Journalled):
             # struct is not reliable as it depends on qscript so now we just try everything...
             struct = gromacs.utilities.find_first(kwargs['struct'], suffices=['pdb', 'gro'])
             if struct is None:
-                logger.error("Starting structure %(struct)r does not exist (yet)" % kwargs)
+                logger.error("Starting structure {struct!r} does not exist (yet)".format(**kwargs))
                 raise IOError(errno.ENOENT, "Starting structure not found", kwargs['struct'])
             else:
                 logger.info("Found starting structure %r (instead of %r).", struct, kwargs['struct'])
@@ -507,7 +507,7 @@ class Simulation(Journalled):
 
     def _checknotempty(self, value, name):
         if value is None or value == "":
-            raise ValueError("Parameter %s cannot be empty." % name)
+            raise ValueError("Parameter {0!s} cannot be empty.".format(name))
         return value
 
     def _lastnotempty(self, l):

--- a/mdpow/fep.py
+++ b/mdpow/fep.py
@@ -400,8 +400,7 @@ class Gsolv(Journalled):
                 if simulation.solvent_type == solvent:
                     self.solvent_type = simulation.solvent_type
                 else:
-                    errmsg = "Solvent mismatch: simulation was run for %s but Gsolv is set up for %s" % \
-                        (simulation.solvent_type, solvent)
+                    errmsg = "Solvent mismatch: simulation was run for {0!s} but Gsolv is set up for {1!s}".format(simulation.solvent_type, solvent)
                     logger.error(errmsg)
                     raise ValueError(errmsg)
             else:
@@ -413,7 +412,7 @@ class Gsolv(Journalled):
 
             for attr in required_args:
                 if self.__getattribute__(attr) is None:
-                    raise ValueError("A value is required for %(attr)r." % vars())
+                    raise ValueError("A value is required for {attr!r}.".format(**vars()))
 
             # fix struct (issue with qscripts being independent from rest of code)
             if not os.path.exists(self.struct):
@@ -504,7 +503,7 @@ class Gsolv(Journalled):
 
         Typically something like ``VDW/0000``, ``VDW/0500``, ..., ``Coulomb/1000``
         """
-        return os.path.join(self.component_dirs[component], "%04d" % (1000 * lmbda))
+        return os.path.join(self.component_dirs[component], "{0:04d}".format((1000 * lmbda)))
 
     def wdir(self, component, lmbda):
         """Return rooted path to the work directory for *component* and *lmbda*.
@@ -519,7 +518,7 @@ class Gsolv(Journalled):
 
     def tasklabel(self, component, lmbda):
         """Batch submission script name for a single task job."""
-        return self.molecule[:3]+'_'+self.schedules[component].label+"%04d" % (1000 * lmbda)
+        return self.molecule[:3]+'_'+self.schedules[component].label+"{0:04d}".format((1000 * lmbda))
 
     def arraylabel(self, component):
         """Batch submission script name for a job array."""
@@ -606,7 +605,7 @@ class Gsolv(Journalled):
 
         # note that all arguments pertinent to the submission scripts should be in kwargs
         # and have been set in setup() so that it is easy to generate array job scripts
-        logger.info("Preparing %(component)s for lambda=%(lmbda)g" % vars())
+        logger.info("Preparing {component!s} for lambda={lmbda:g}".format(**vars()))
 
         wdir = self.wdir(component, lmbda)
         kwargs.setdefault('couple-intramol', 'no')
@@ -956,18 +955,17 @@ g
             iplot = i+1
             subplot(1, nplots, iplot)
             energy = self.results.DeltaA[component]
-            label = r"$\Delta A^{\rm{%s}}_{\rm{%s}} = %.2f\pm%.2f$ kJ/mol" \
-                    % (component, self.solvent_type, energy.value, energy.error)
+            label = r"$\Delta A^{{\rm{{{0!s}}}}}_{{\rm{{{1!s}}}}} = {2:.2f}\pm{3:.2f}$ kJ/mol".format(component, self.solvent_type, energy.value, energy.error)
             errorbar(x, y, yerr=dy, label=label, **kwargs)
             xlabel(r'$\lambda$')
             legend(loc='best')
             xlim(-0.05, 1.05)
         subplot(1, nplots, 1)
         ylabel(r'$dV/d\lambda$ in kJ/mol')
-        title(r"Free energy difference $\Delta A^{0}_{\rm{%s}}$" % self.solvent_type)
+        title(r"Free energy difference $\Delta A^{{0}}_{{\rm{{{0!s}}}}}$".format(self.solvent_type))
         subplot(1, nplots, 2)
-        title(r"for %s: $%.2f\pm%.2f$ kJ/mol" %
-              ((self.molecule,) + self.results.DeltaA.Helmholtz.astuple()))
+        title(r"for {0!s}: ${1:.2f}\pm{2:.2f}$ kJ/mol".format(*
+              ((self.molecule,) + self.results.DeltaA.Helmholtz.astuple())))
 
 
     def qsub(self, script=None):
@@ -984,7 +982,7 @@ g
             elif script in scripts:
                 s = script
             else:
-                errmsg = "No script matching %(script)r in %(scripts)r" % vars()
+                errmsg = "No script matching {script!r} in {scripts!r}".format(**vars())
                 logger.error(errmsg)
                 raise ValueError(errmsg)
             return s
@@ -996,7 +994,7 @@ g
                 logger.debug("[%s] submitting locally: %s", " ".join(cmd), component)
                 rc = call(cmd)
                 if rc != 0:
-                    errmsg = "submitting job %(s)r failed with rc=%(rc)d" % vars()
+                    errmsg = "submitting job {s!r} failed with rc={rc:d}".format(**vars())
                     logger.error(errmsg)
                     raise OSError(errmsg)
 
@@ -1015,7 +1013,7 @@ g
         raise NotImplementedError
 
     def __repr__(self):
-        return "%s(filename=%r)" % (self.__class__.__name__, self.filename)
+        return "{0!s}(filename={1!r})".format(self.__class__.__name__, self.filename)
 
 class Ghyd(Gsolv):
     """Sets up and analyses MD to obtain the hydration free energy of a solute."""

--- a/mdpow/filelock.py
+++ b/mdpow/filelock.py
@@ -43,7 +43,7 @@ class FileLock(object):
             the maximum timeout and the delay between each attempt to lock.
         """
         self.is_locked = False
-        self.lockfile = os.path.join(os.getcwd(), "%s.lock" % file_name)
+        self.lockfile = os.path.join(os.getcwd(), "{0!s}.lock".format(file_name))
         self.file_name = file_name
         self.timeout = timeout
         self.delay = delay

--- a/mdpow/restart.py
+++ b/mdpow/restart.py
@@ -90,8 +90,7 @@ class Journal(object):
             return self.__current
         def fset(self, stage):
             if not stage in self.stages:
-                raise ValueError("Can only assign a registered stage from %r, not %r" %
-                                 (self.stages, stage))
+                raise ValueError("Can only assign a registered stage from {0!r}, not {1!r}".format(self.stages, stage))
             self.__current = stage
         def fdel(self):
             self.__current = None
@@ -104,7 +103,7 @@ class Journal(object):
             return self.__incomplete
         def fset(self, stage):
             if not stage in self.stages:
-                raise ValueError("can only assign a registered stage from %(stages)r" % vars(self))
+                raise ValueError("can only assign a registered stage from {stages!r}".format(**vars(self)))
             self.__incomplete = stage
         def fdel(self):
             self.__incomplete = None
@@ -149,7 +148,7 @@ class Journal(object):
         del self.current
 
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, self.stages)
+        return "{0!s}({1!r})".format(self.__class__.__name__, self.stages)
 
 class Journalled(object):
     """A base class providing methods for journalling and restarts.
@@ -195,7 +194,7 @@ class Journalled(object):
 
         """
         if protocol not in self.protocols:
-            raise ValueError("%r: protocol must be one of %r" % (protocol, self.protocols))
+            raise ValueError("{0!r}: protocol must be one of {1!r}".format(protocol, self.protocols))
         try:
             return self.__getattribute__(protocol)
         except AttributeError:
@@ -235,7 +234,7 @@ class Journalled(object):
             self.filename = os.path.abspath(filename)
         with open(self.filename, 'wb') as f:
             cPickle.dump(self, f, protocol=cPickle.HIGHEST_PROTOCOL)
-        logger.debug("Instance pickled to %(filename)r" % vars(self))
+        logger.debug("Instance pickled to {filename!r}".format(**vars(self)))
 
     def load(self, filename=None):
         """Re-instantiate class from pickled file.
@@ -256,4 +255,4 @@ class Journalled(object):
         with open(filename, 'rb') as f:
             instance = cPickle.load(f)
         self.__dict__.update(instance.__dict__)
-        logger.debug("Instance loaded from %(filename)r" % vars())
+        logger.debug("Instance loaded from {filename!r}".format(**vars()))

--- a/mdpow/run.py
+++ b/mdpow/run.py
@@ -123,7 +123,7 @@ def runMD_or_exit(S, protocol, params, cfg, **kwargs):
         try:
             dirname = S.dirs[protocol]
         except KeyError:
-            raise ValueError("S.dirs does not have protocol %r" % protocol)
+            raise ValueError("S.dirs does not have protocol {0!r}".format(protocol))
         except AttributeError:
             raise ValueError("supply dirname as a keyword argument")
     simulation_done = False
@@ -181,7 +181,7 @@ def equilibrium_simulation(cfg, solvent, **kwargs):
     if topdir is None:
         topdir = cfg.get("setup", "name")
     dirname = os.path.join(topdir, Simulation.dirname_default)
-    savefilename = os.path.join(topdir, "%(solvent)s.simulation" % vars())
+    savefilename = os.path.join(topdir, "{solvent!s}.simulation".format(**vars()))
 
     # output to screen or hidden?
     set_gromacsoutput(cfg)
@@ -275,7 +275,7 @@ def fep_simulation(cfg, solvent, **kwargs):
     # and NOT topdir (bit of an historic inconsistency)
     savefilename = os.path.join(dirname, Simulation.__name__ + os.extsep + 'fep')
     # need pickle files for the equilibrium simulation ... another nasty guess:
-    equil_savefilename = os.path.join(topdir, "%(solvent)s.simulation" % vars())
+    equil_savefilename = os.path.join(topdir, "{solvent!s}.simulation".format(**vars()))
     try:
         equil_S = EquilSimulation(filename=equil_savefilename)
     except IOError, err:

--- a/scripts/mdpow-cfg2yaml.py
+++ b/scripts/mdpow-cfg2yaml.py
@@ -14,7 +14,7 @@ if not sys.argv[1].split(".")[1] == "cfg":
     print("Please include *file*.cfg to convert to *file*.yml. Exiting...")
     exit(1)
 
-print("Converting %s.cfg ..." % sys.argv[1].split(".")[0])
+print("Converting {0!s}.cfg ...".format(sys.argv[1].split(".")[0]))
 
 full_file = []
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Becksteinlab:MDPOW?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:Becksteinlab:MDPOW?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)