### PR TITLE
dynamic version information

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -46,7 +46,7 @@ copyright = u'2010–2016, Ian Kenney, Bogdan Iorga, and Oliver Beckstein'
 # built documents.
 #
 # Dynamically calculate the version based on mdpow.VERSION.
-packageversion = __import__('mdpow').get_version()
+packageversion = __import__('mdpow.version').get_version()
 
 # The short X.Y version.
 version = '.'.join(packageversion.split('.')[:2])

--- a/mdpow/__init__.py
+++ b/mdpow/__init__.py
@@ -498,26 +498,10 @@ through the thermodynamic integration and the subsequent thermodynamic sums
 """
 from __future__ import absolute_import
 
+from .version import VERSION, get_version, get_version_tuple
 from . import log
 
 __all__ = ['fep', 'equil']
-
-#: Package version; this is the only place where it is set.
-VERSION = 0,6,0
-#: Set to ``True`` for a release. If set to ``False`` then the patch level
-#: will have the suffix "-dev".
-RELEASE = False
-if not RELEASE:
-    VERSION = VERSION[:2] + (str(VERSION[2]) + '-dev',)
-
-def get_version():
-    """Return current package version as a string."""
-    return ".".join(map(str,VERSION))
-
-def get_version_tuple():
-    """Return current package version as a tuple (*MAJOR*, *MINOR*, *PATCHLEVEL*)."""
-    return tuple(map(str,VERSION))
-
 
 
 def create_logger(logfile="mdpow.log"):
@@ -541,9 +525,11 @@ def log_banner():
 logger = create_logger()
 log_banner()
 
-# config can write status messages: they should come AFTER the banner
-# so the import should not be at the top.
-from . import config
+# AVOID IMPORTS OF OTHER PACKAGES IN __init__.py; only standard
+# library and mdpow.log are allowed. Anything else will break 'pip
+# install' because in setup.py we import mdpow.version (and thus
+# __init__.py) for the dynamic version information BEFORE pip has a
+# chance to install dependencies.
 
 # XXX move to tables XXX
 #: Avogadro's constant |NA| in mol^-1 (`NA NIST value`_).

--- a/mdpow/log.py
+++ b/mdpow/log.py
@@ -21,6 +21,12 @@ In modules simply use::
 
 from __future__ import absolute_import
 
+# log is the only package that is imported in __init__ so it MAY NOT
+# HAVE ANY DEPENDENCIES except standard library; in particular, DO NOT
+# 'from . import config' or similar because it will break pip install
+# (because in setup.py we import mdpow.version (and thus __init__.py)
+# for the dynamic version information)
+
 import logging
 
 def create(logname, logfile):

--- a/mdpow/run.py
+++ b/mdpow/run.py
@@ -46,9 +46,9 @@ import errno
 
 import gromacs.run
 
+from .config import get_configuration, set_gromacsoutput
 from . import equil
 from . import fep
-from .config import get_configuration, set_gromacsoutput
 from .restart import checkpoint
 
 import logging

--- a/mdpow/version.py
+++ b/mdpow/version.py
@@ -1,0 +1,48 @@
+# POW package __init__.py
+# Copyright (c) 2010 Oliver Beckstein <orbeckst@gmail.com>
+# Released under the GNU Public License 3 (or higher, your choice)
+# See the file COPYING for details.
+
+"""\
+MDPOW version information
+=========================
+
+MDPOW uses `semantic versioning`_ with the release number consisting
+of a triplet *MAJOR.MINOR.PATCH*. *PATCH* releases are bug fixes or
+updates to docs or meta data only and do not introduce new features or
+change the API. Within a *MAJOR* release, the user API is stable
+except during the development cycles with MAJOR = 0 where the API may
+also change (rarely) between MINOR releases. *MINOR* releases can
+introduce new functionality or deprecate old ones.
+
+Development versions will have the suffix *-dev* after the version
+string.
+
+.. _semantic versioning: http://semver.org
+
+Accessing release information
+-----------------------------
+
+User code should use :func:`get_version` or `get_version_tuple`.
+
+.. autodata:: VERSION
+.. autofunction:: get_version
+.. autofunction:: get_version_tuple
+
+"""
+
+#: Package version; this is the only place where it is set.
+VERSION = 0,6,0
+#: Set to ``True`` for a release. If set to ``False`` then the patch level
+#: will have the suffix "-dev".
+RELEASE = False
+if not RELEASE:
+    VERSION = VERSION[:2] + (str(VERSION[2]) + '-dev',)
+
+def get_version():
+    """Return current package version as a string."""
+    return ".".join(map(str,VERSION))
+
+def get_version_tuple():
+    """Return current package version as a tuple (*MAJOR*, *MINOR*, *PATCHLEVEL*)."""
+    return tuple(map(str,VERSION))

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,14 @@
 from setuptools import setup, find_packages
 
 # Dynamically calculate the version based on VERSION.
-# version = __import__('mdpow').get_version()
-version = '0.6.0' # dynamic calculation breaks clean installation
+version = __import__('mdpow.version').get_version()
+
 setup(name="POW",
       version=version,
       description="A library for computing octanol/water partitioning coefficients",
       long_description="""The POW module simplifies the setup and
 execution of free energy calculations of small molecules in water and
-and other solvents such as octanol and cyclohexane. 
+and other solvents such as octanol and cyclohexane.
 It uses Gromacs (http://www.gromacs.org) for the molecular dynamics
 (MD) simulations and relies on GromacsWrapper
 (https://github.com/Becksteinlab/GromacsWrapper)
@@ -24,15 +24,15 @@ It uses Gromacs (http://www.gromacs.org) for the molecular dynamics
       url="https://github.com/Becksteinlab/MDPOW",
       keywords="science Gromacs analysis 'molecular dynamics'",
       packages=find_packages(exclude=['examples']),
-      scripts = ['scripts/mdpow-pow', 
+      scripts = ['scripts/mdpow-pow',
                  'scripts/mdpow-pcw',
                  'scripts/mdpow-ghyd',
                  'scripts/mdpow-check',
-                 'scripts/mdpow-rebuild-fep', 
-		         'scripts/mdpow-rebuild-simulation',
+                 'scripts/mdpow-rebuild-fep',
+                         'scripts/mdpow-rebuild-simulation',
                  'scripts/mdpow-equilibrium',
                  'scripts/mdpow-fep',
-		         'scripts/mdpow-cfg2yaml.py',
+                         'scripts/mdpow-cfg2yaml.py',
                  'scripts/mdpow-solvationenergy'
                  ],
       package_data={'mdpow': ['top/*.dat', 'top/*.gro', 'top/*.itp',


### PR DESCRIPTION
Separated versioning code into `mdpow.version`. This *should* allow us to re-enable dyamically computed version information in `setup.py`.