### PR TITLE
validated m24 water model

### DIFF
--- a/mdpow/templates/system.top
+++ b/mdpow/templates/system.top
@@ -9,11 +9,11 @@
 ; Include forcefield parameters
 #include "oplsaa.ff/forcefield.itp"
 
-; Include compound topology
-#include "compound.itp"
-
 ; Include solvent topology
 #include "oplsaa.ff/tip4p.itp"
+
+; Include compound topology
+#include "compound.itp"
 
 ; Include topology for OPLS/AA ions 
 #include "oplsaa.ff/ions_opls.itp"


### PR DESCRIPTION
Fixed the bug with the atomtypes order. The m24 water model is now implemented and validated. The issue #46 is solved and will be closed.