### PR TITLE
m24 water model with new atom type opls_111_m24 (#46)

### DIFF
--- a/mdpow/templates/system.top
+++ b/mdpow/templates/system.top
@@ -9,11 +9,11 @@
 ; Include forcefield parameters
 #include "oplsaa.ff/forcefield.itp"
 
-; Include solvent topology
-#include "oplsaa.ff/tip4p.itp"
-
 ; Include compound topology
 #include "compound.itp"
+
+; Include solvent topology
+#include "oplsaa.ff/tip4p.itp"
 
 ; Include topology for OPLS/AA ions 
 #include "oplsaa.ff/ions_opls.itp"

--- a/mdpow/top/oplsaa.ff/ffnonbonded.itp
+++ b/mdpow/top/oplsaa.ff/ffnonbonded.itp
@@ -846,3 +846,8 @@
  opls_9008  Rb+   37     5.46780     1.000       A    5.60000e-01  2.09200e-03 
  opls_9009  Cs+   55   132.90540     1.000       A    6.20000e-01  2.09200e-03 
  opls_9010  NH4+   7    18.03870     1.000       A    5.34000e-01  2.09200e-03 
+
+; TIP3P-M24 water model from Shirts and Pande. J. Chem. Phys., 122(13), 2005. doi:10.1063/1.1877132
+; TIP3P geometry, epsilon: 0.24 kcal/mol, sigma: 3.111 Å
+ opls_111_m24   OW  8      9.95140    -0.834       A    3.11100e-01  1.00440e-00
+

--- a/mdpow/top/oplsaa.ff/m24.itp
+++ b/mdpow/top/oplsaa.ff/m24.itp
@@ -3,9 +3,10 @@
 ; epsilon: 0.24 kcal/mol
 ; sigma: 3.111 Å
 
-[ atomtypes ]
+; the new atom type was inserted in the ffnonbonded.itp file, as opls_111_m24
+;[ atomtypes ]
 ; name  bond_type    mass    charge   ptype          sigma      epsilon
- opls_111   OW  8      9.95140    -0.834       A    3.11100e-01  1.00440e-00
+; opls_111   OW  8      9.95140    -0.834       A    3.11100e-01  1.00440e-00
 
 [ moleculetype ]
 ; molname	nrexcl
@@ -13,9 +14,9 @@ SOL		2
 
 [ atoms ]
 ; id	at type	res nr 	residu name	at name		cg nr	charge
-1     opls_111  1       SOL              OW             1       -0.834
-2     opls_112  1       SOL             HW1             1        0.417
-3     opls_112  1       SOL             HW2             1        0.417
+1     opls_111_m24  1       SOL              OW             1       -0.834
+2     opls_112      1       SOL             HW1             1        0.417
+3     opls_112      1       SOL             HW2             1        0.417
 
 #ifndef FLEXIBLE
 [ settles ]


### PR DESCRIPTION
m24 water model implemented with a new atom type, opls_111_m24 (#46)