### PR TITLE
Installing PyBOL from PyPi instead of GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,12 @@ install:
   - conda install -c becksteinlab gromacs-$GMX_VERSION
 
   # install test tools
-  - pip install git+git://github.com/ianmkenney/PyBOL.git
+  - pip install pybol
   - pip install codecov
   - pip install pytest-cov
   - pip install pytest-pep8
+
+  # install MDPOW
   - pip install -e .
 
   # source gromacs

--- a/mdpow/tests/test_equilibration_script.py
+++ b/mdpow/tests/test_equilibration_script.py
@@ -1,6 +1,6 @@
 import os.path
 import tempdir as td
-import manifest
+import pybol
 
 from gromacs.utilities import in_dir
 
@@ -14,7 +14,7 @@ class TestEquilibriumScript(object):
         self.old_path = os.getcwd()
         self.resources = os.path.join(
             self.old_path, 'mdpow', 'tests', 'testing_resources')
-        m = manifest.Manifest(os.path.join(self.resources, 'manifest.yml'))
+        m = pybol.Manifest(os.path.join(self.resources, 'manifest.yml'))
         m.assemble('base', self.tmpdir.name)
 
     def teardown(self):

--- a/mdpow/tests/test_fep_script.py
+++ b/mdpow/tests/test_fep_script.py
@@ -1,6 +1,6 @@
 import tempdir as td
 import os
-import manifest
+import pybol
 from mdpow.equil import Simulation
 from gromacs.utilities import in_dir
 
@@ -13,7 +13,7 @@ class TestFEPScript(object):
         self.old_path = os.getcwd()
         self.resources = os.path.join(
             self.old_path, 'mdpow', 'tests', 'testing_resources')
-        self.m = manifest.Manifest(os.path.join(self.resources,'manifest.yml'))
+        self.m = pybol.Manifest(os.path.join(self.resources,'manifest.yml'))
         self.m.assemble('md_npt',self.tmpdir.name)
 
         S = Simulation(filename=os.path.join(


### PR DESCRIPTION
With [PyBOL](https://github.com/ianmkenney/PyBOL) now on [PyPi](https://pypi.python.org/pypi/pybol/0.2.0), we should now install from the packaged releases instead of the master branch on GitHub.