### PR TITLE
Enclosed all strings in the runinput.yml file in quotes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,10 +6,13 @@ Add summary of changes for each release. Use ISO dates. Reference
 GitHub issues numbers and PR numbers.
 
 2016-xx-xx    0.6.1
-orbeckst, iorga
+orbeckst, iorga, ianmkenney
 
 * removed unused analysis.py and analysis/thermodynamics.py
-* supported water models: TIP4P, TIP3P, TIP5P, SPC, SPC/E, and new: M24 (modified TIP3P, #46)
+* supported water models: TIP4P, TIP3P, TIP5P, SPC, SPC/E, and
+  new: M24 (modified TIP3P, #46)
+* fixed sc-alpha can only take integer powers (#71)
+* use PyBOL for building the testing environment
 
 
 2016-06-29    0.6.0

--- a/doc/examples/benzene.yml
+++ b/doc/examples/benzene.yml
@@ -2,22 +2,23 @@
 # use with 
 #   - mdpow-equilibrium
 #   - mdpow-fep
-
+#
+# Note: enclose strings (especially names) with quotes.
 
 DEFAULT:
-    qscripts: local.sh
+    qscripts: "local.sh"
 
 setup:
-    name: benzene
+    name: "benzene"
          # common, descriptive name, e.g. benzene
-    molecule: BNZ
+    molecule: "BNZ"
          # Gromacs [ molecule ] identifier from the itp file (typically a 3-letter code)
-    watermodel: tip4p
+    watermodel: "tip4p"
          # water model available in Gromacs (OPLS-AA):
          # tip4p, tip5p, tip3p, spc, spce     
-    itp: benzene/benzene.itp
+    itp: "benzene/benzene.itp"
          # Gromacs itp file name 
-    structure: benzene/benzene.pdb
+    structure: "benzene/benzene.pdb"
          # coordinate file name (pdb, gro, ... anything that Gromacs can read)
     maxwarn: 0
          # maximum number of warnings tolerated by grompp during setup
@@ -28,7 +29,7 @@ setup:
 # energy minimization
 
 energy_minimize:
-    mdp: em_opls.mdp
+    mdp: "em_opls.mdp"
          # run parameter file for Gromacs;
          # (will be searched as (1) absolute path, (2) in current directory (3)
          # in the package templates)
@@ -37,14 +38,14 @@ energy_minimize:
 # short simulation with a time step of 0.1 fs to gently relax steric clashes
 
 MD_relaxed:
-    qscript: local.sh
+    qscript: "local.sh"
          # queuing system scripts to produce
     runlocal: True
          # True: launch Gromacs mdrun and wait for it
          # False: produce queuing system scripts and stop
     runtime: 1
          # run time in ps
-    mdp: NPT_opls.mdp
+    mdp: "NPT_opls.mdp"
          #  run parameter file for Gromacs;
          # (will be searched as (1) absolute path, (2) in current directory (3)
          # in the package templates)
@@ -54,7 +55,7 @@ MD_relaxed:
 # time step of 2 fs.
 
 MD_NPT:
-    qscript: local.sh
+    qscript: "local.sh"
          # queuing system scripts to produce
     runtime: 10
          # simulation run time in ps (for this example, a VERY short
@@ -62,16 +63,16 @@ MD_NPT:
     runlocal: True
          # True: launch Gromacs mdrun and wait for it
          # False: produce queuing system scripts and stop
-    mdp: NPT_opls.mdp
+    mdp: "NPT_opls.mdp"
          # run parameter file for Gromacs;
          # (will be searched as (1) absolute path, (2) in current directory (3)
          # in the package templates)
          # special index groups  __main__ __environment__ can be used
 
 FEP:
-    method: BAR
+    method: "BAR"
          # BAR or TI
-    qscript: local.sh
+    qscript: "local.sh"
          # queuing system scripts to produce
     runtime: 25
          # run time in ps for each free energy window (the run time
@@ -88,18 +89,18 @@ FEP:
          #  necessarily cancel.  It may be necessary to decrease the reciprocal space
          #  energy, and increase the cutoff radius to get sufficiently close matches
          #  to energies with free energy turned off.
-    mdp: bar_opls.mdp
+    mdp: "bar_opls.mdp"
          # run parameter file for Gromacs;
          # (will be searched as (1) absolute path, (2) in current directory (3)
          # in the package templates)
          # special index groups  __main__ __environment__ can be used
 
 FEP_schedule_Coulomb:
-    name: Coulomb
-    description: dis-charging vdw+q --> vdw
-    label: Coul
-    couple_lambda0: vdw-q
-    couple_lambda1: vdw
+    name: "Coulomb"
+    description: "dis-charging vdw+q --> vdw"
+    label: "Coul"
+    couple_lambda0: "vdw-q"
+    couple_lambda1: "vdw"
          # soft core alpha: linear scaling for coulomb (sc_alpha = 0)
          # ignore the other sc_*
     sc_alpha: 0
@@ -108,14 +109,14 @@ FEP_schedule_Coulomb:
     lambdas: 0, 0.25, 0.5, 0.75, 1.0
 
 FEP_schedule_VDW:
-    name: vdw
-    description: decoupling vdw --> none
-    label: VDW
-    couple_lambda0: vdw
-    couple_lambda1: none
+    name: "vdw"
+    description: "decoupling vdw --> none"
+    label: "VDW"
+    couple_lambda0: "vdw"
+    couple_lambda1: "none"
          # recommended values for soft cores (Mobley, Shirts et al)
     sc_alpha: 0.5
-    sc_power: 1.0 
+    sc_power: 1
     sc_sigma: 0.3
     lambdas: 0.0, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1
 

--- a/doc/sphinx/source/scripts.txt
+++ b/doc/sphinx/source/scripts.txt
@@ -43,8 +43,8 @@ Equilibrium simulations
 
 The :program:`mdpow-equilibrium` script
 
-* sets up equilibrium MD simulations for the solvents *water* or
-  *octanol*
+* sets up equilibrium MD simulations for the solvents (e.g., *water* or
+  *octanol*)
 * runs **energy minimization**, **MD_relaxed**, and **MD_NPT**
   protocols; the user can choose if she wants to launch
   :program:`mdrun` herself (e.g. on a cluster) or let the script do it
@@ -55,20 +55,29 @@ The script runs essentially the same steps as described in the tutorial
 input file and it allows one to stop and continue and the protocol
 transparently.
 
-It requires as at least Gromacs 4.0.5 ready to run (check that all commands can
+It requires as at least Gromacs 4.6.5 ready to run (check that all commands can
 be found). The required **input** is
 
-  1. a run configuration file;
+  1. a run configuration file (*runinput.yml*);
   2. a structure file (PDB or GRO) for the compound
   3. a Gromacs ITP file for the compound (OPLS/AA force field)
 
-A template *RUNFILE* can be generated with 
-:option:`mdpow-equilibrium --get-template`.
+A template *RUNFILE* can be generated with :option:`mdpow-get-runinput
+runinput.yml`, which will copy the default run input file bundled with
+MDPOW and put it in the current directory under the name
+``runinput.yml``.
 
-For an example of a *RUNFILE* see :download:`benzene_runinput.cfg
-<../../examples/benzene_runinput.cfg>`. It is recommended to use absolute paths
-to file names. The run input file uses :mod:`ConfigParser`, which describes the
-syntax of the file.
+For an example of a *RUNFILE* see :download:`benzene.yml
+<../../examples/benzene.yml>`. It is recommended to use absolute paths
+to file names. The run input file uses `YAML`_ syntax (and is parsed
+by :mod:`yaml`).
+
+.. _YAML: http://yaml.org/
+
+.. Note:: It is recommended to enclose all strings in the input file
+          in quotes, especially if they can be interpreted as
+          numbers. For example, a name "005" would be interpreted as
+          the number 5 unless explicitly quoted.
 
 The script keeps track of the stages of the simulation protocol and allows the
 user to **restart from the last completed stage**. For instance, one can use the
@@ -100,13 +109,9 @@ Usage of the command:
 
       show this help message and exit
 
-   .. cmdoption:: --get-template
-
-      generate a template RUNFILE and exit
-
    .. cmdoption:: -S <NAME>, --solvent=<NAME>
 
-      solvent ``<NAME>`` for compound, can be 'water' or 'octanol' [water]
+      solvent ``<NAME>`` for compound, can be 'water', 'octanol', 'cyclohexane' [water]
 
    .. cmdoption:: -d <DIRECTORY>, --dirname=<DIRECTORY>
 

--- a/mdpow/config.py
+++ b/mdpow/config.py
@@ -4,8 +4,8 @@
 # See the file COPYING for details.
 
 """
-:mod:`mdpow.config` -- Configuration for POW
-==========================================================
+:mod:`mdpow.config` -- Configuration for MDPOW
+==============================================
 
 The config module provides configurable options for the whole package;
 eventually it might grow into a more sophisticated configuration system but

--- a/mdpow/templates/runinput.yml
+++ b/mdpow/templates/runinput.yml
@@ -6,14 +6,14 @@
 
 
 DEFAULT:
-    qscripts: local.sh
+    qscripts: 'local.sh'
 
 setup:
     name: None
          # common, descriptive name, e.g. benzene
     molecule: None
          # Gromacs [ molecule ] identifier from the itp file (typically a 3-letter code)
-    watermodel: tip4p
+    watermodel: 'tip4p'
          # water model available in Gromacs (OPLS-AA):
          # tip4p, tip5p, tip3p, spc, spce, m24
     itp: None
@@ -27,43 +27,43 @@ setup:
          # False: only show the MDPOW messages
 
 energy_minimize:
-    mdp: em_opls.mdp
+    mdp: 'em_opls.mdp'
          # run parameter file for Gromacs;
          # (will be searched as (1) absolute path, (2) in current directory (3)
          # in the package templates)
 
 MD_relaxed:
-    qscript: local.sh
+    qscript: 'local.sh'
          # queuing system scripts to produce
     runlocal: True
          # True: launch Gromacs mdrun and wait for it
          # False: produce queuing system scripts and stop
     runtime: 5
          # run time in ps
-    mdp: NPT_opls.mdp
+    mdp: 'NPT_opls.mdp'
          #  run parameter file for Gromacs;
          # (will be searched as (1) absolute path, (2) in current directory (3)
          # in the package templates)
          # special index groups  __main__ __environment__ can be used
 
 MD_NPT:
-    qscript: local.sh
+    qscript: 'local.sh'
          # queuing system scripts to produce
     runtime: 50000
          # simulation run time in ps [50 ns is generous, probably can be shorter]
     runlocal: False
          # True: launch Gromacs mdrun and wait for it
          # False: produce queuing system scripts and stop
-    mdp: NPT_opls.mdp
+    mdp: 'NPT_opls.mdp'
          # run parameter file for Gromacs;
          # (will be searched as (1) absolute path, (2) in current directory (3)
          # in the package templates)
          # special index groups  __main__ __environment__ can be used
 
 FEP:
-    method: BAR
+    method: 'BAR'
          # BAR or TI
-    qscript: local.sh
+    qscript: 'local.sh'
          # queuing system scripts to produce
     runtime: 5000
          # run time in ps for each free energy window
@@ -79,18 +79,18 @@ FEP:
          #  necessarily cancel.  It may be necessary to decrease the reciprocal space
          #  energy, and increase the cutoff radius to get sufficiently close matches
          #  to energies with free energy turned off.
-    mdp: bar_opls.mdp
+    mdp: 'bar_opls.mdp'
          # run parameter file for Gromacs;
          # (will be searched as (1) absolute path, (2) in current directory (3)
          # in the package templates)
          # special index groups  __main__ __environment__ can be used
 
 FEP_schedule_Coulomb:
-    name: Coulomb
-    description: dis-charging vdw+q --> vdw
-    label: Coul
-    couple_lambda0: vdw-q
-    couple_lambda1: vdw
+    name: 'Coulomb'
+    description: 'dis-charging vdw+q --> vdw'
+    label: 'Coul'
+    couple_lambda0: 'vdw-q'
+    couple_lambda1: 'vdw'
          # soft core alpha: linear scaling for coulomb (sc_alpha = 0)
          # ignore the other sc_*
     sc_alpha: 0
@@ -99,11 +99,11 @@ FEP_schedule_Coulomb:
     lambdas: 0, 0.25, 0.5, 0.75, 1.0
 
 FEP_schedule_VDW:
-    name: vdw
-    description: decoupling vdw --> none
-    label: VDW
-    couple_lambda0: vdw
-    couple_lambda1: none
+    name: 'vdw'
+    description: 'decoupling vdw --> none'
+    label: 'VDW'
+    couple_lambda0: 'vdw'
+    couple_lambda1: 'none'
          # recommended values for soft cores (Mobley, Shirts et al)
     sc_alpha: 0.5
     sc_power: 1.0 


### PR DESCRIPTION
This is to fix the issue #68  if a string appears to be a number (i.e. 001 --> 1) when it is meant to be a string
