### PR TITLE
Better boxes: allow selection of boxtype and distance

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@ orbeckst
 
 * renamed package to MDPOW
 * removed all generated docs from package
+* config parser MERGES user runinput.yml with the package defaults
+  (#8)
 
 
 2017-05-02    0.6.1

--- a/doc/examples/benzene.yml
+++ b/doc/examples/benzene.yml
@@ -20,6 +20,13 @@ setup:
          # Gromacs itp file name 
     structure: "benzene/benzene.pdb"
          # coordinate file name (pdb, gro, ... anything that Gromacs can read)
+    distance:  None
+         # minimum distance between solute and box face (by default
+         # (None) this is set to a 1.0 nm for water and 1.5 nm for
+         # other solvents)    
+    boxtype: dodecahedron
+         # box type understood by Gromacs 'gmx editconf' (cubic,
+         # triclinic, octahedron, dodecahedron    
     maxwarn: 0
          # maximum number of warnings tolerated by grompp during setup
     gromacsoutput: True

--- a/mdpow/run.py
+++ b/mdpow/run.py
@@ -194,6 +194,11 @@ def equilibrium_simulation(cfg, solvent, **kwargs):
             distance = cfg.get('setup', 'distance')
         except KeyError:
             distance = None # if no distance is specified, None = default
+        try:
+            boxtype = cfg.get('setup', 'boxtype')
+        except KeyError:
+            boxtype = None # if no distance is specified, None = default
+
 
         solventmodel = None
         if solvent == "water":
@@ -215,7 +220,9 @@ def equilibrium_simulation(cfg, solvent, **kwargs):
     if S.journal.has_not_completed("energy_minimize"):
         maxwarn = cfg.getint("setup", "maxwarn") or None
         S.topology(itp=cfg.getpath("setup", "itp"))
-        S.solvate(struct=cfg.getpath("setup", "structure"), maxwarn=maxwarn)
+        S.solvate(struct=cfg.getpath("setup", "structure"),
+                  bt=cfg.get("setup", "boxtype"),
+                  maxwarn=maxwarn)
         S.energy_minimize(maxwarn=maxwarn)
         checkpoint('energy_minize', S, savefilename)
     else:

--- a/mdpow/templates/runinput.yml
+++ b/mdpow/templates/runinput.yml
@@ -1,9 +1,5 @@
-# default run input file for the the equilibrium simulation
+# default run input file for the the equilibrium and FEP simulations;
 # values can be overriden from your own configuration file
-
-# XXX maybe define which queuing system to submit to, so that this can be
-# XXX done automatically through GromacsWrapper.
-
 
 DEFAULT:
     qscripts: 'local.sh'
@@ -22,6 +18,13 @@ setup:
          # coordinate file name (pdb, gro, ... anything that Gromacs can read)
     maxwarn: 0
          # maximum number of warnings tolerated by grompp during setup
+    distance:  None
+         # minimum distance between solute and box face (by default
+         # (None) this is set to a 1.0 nm for water and 1.5 nm for
+         # other solvents)    
+    boxtype: dodecahedron
+         # box type understood by Gromacs 'gmx editconf' (cubic,
+         # triclinic, octahedron, dodecahedron
     gromacsoutput: False
          # True: print output from Gromacs command to screen (useful for debugging)
          # False: only show the MDPOW messages

--- a/mdpow/tests/test_runinput.py
+++ b/mdpow/tests/test_runinput.py
@@ -3,7 +3,7 @@ import os.path
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
-import mdpow
+import mdpow.config
 
 class TestAlteredConfig(object):
     params_altered = {
@@ -19,6 +19,8 @@ class TestAlteredConfig(object):
             'structure': 'some_molecules_structure',
             'watermodel': 'spce',
             'maxwarn': 2,
+            'distance': None,          # default (not in this input file)
+            'boxtype': 'dodecahedron', # default (not in this input file)
             'gromacsoutput': True,
             },
         'energy_minimize':


### PR DESCRIPTION
- minimum distance and boxtype can be set in tthe `setup` section of the yaml file
- added and documented proper kwarg processing to methods in `equil.Simulation`
- updated default `runinput.yml`
- fixed #8 (user yml is now merged with package defaults)