### PR TITLE
removed openany(..., buffering=...) kwarg

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@ CHANGES for MDPOW
 Add summary of changes for each release. Use ISO dates. Reference
 GitHub issues numbers and PR numbers.
 
-2017-xx-xx    0.7.0
+2019-xx-xx    0.7.0
 orbeckst
 
 * renamed package to MDPOW
@@ -14,6 +14,9 @@ orbeckst
   (#8)
 * boxtype and minimum distance (#30) can be set in runinput.yml and are
   documented (#91, #88)
+* fixed: buffering kwarg was removed from openany() so code is
+  compatible with GromacsWrapper >= 0.8.0 (#107)
+
 
 2017-05-02    0.6.1
 orbeckst, iorga, ianmkenney, rhheilma

--- a/mdpow/fep.py
+++ b/mdpow/fep.py
@@ -779,8 +779,10 @@ class Gsolv(Journalled):
                     fnbz2 = xvg + os.path.extsep + "bz2"
                     logger.info("[%s] Compressing dgdl file %r with bzip2", self.dirname, xvg)
                     # speed is similar to 'bzip2 -9 FILE' (using a 1 Mio buffer)
+                    # (Since GW 0.8, openany() does not take kwargs anymore so the write buffer cannot be
+                    # set anymore (buffering=1048576) so the performance might be lower in MDPOW >= 0.7.0)
                     with open(xvg, 'r', buffering=1048576) as source:
-                        with openany(fnbz2, 'w', buffering=1048576) as target:
+                        with openany(fnbz2, 'w') as target:
                             target.writelines(source)
                     if os.path.exists(fnbz2) and os.path.exists(xvg):
                         os.unlink(xvg)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(name="MDPOW",
                         'numkit',
                         'six',
       ],
-      setup_requires=['pytest-runner',],
+      #setup_requires=['pytest-runner',],
       tests_require=['pytest', 'pybol', 'py'],
       zip_safe=True,
 )


### PR DESCRIPTION
- close #107
- removing the buffering kwarg might degrade performance in writing bz2-compressed XVG files but because it is not in GW ≥ 0.8.0 anymore, we don't have a choice but to remove it from MDPOW