### PR TITLE
Remove -DFLEXIBLE line in em_opls.mdp template file

### DIFF
--- a/mdpow/templates/em_opls.mdp
+++ b/mdpow/templates/em_opls.mdp
@@ -2,7 +2,6 @@
 ; Template for energy minimization with OPLS-AA (part of MDPOW)
 
 include                  = 
-; define                   = -DFLEXIBLE
 
 integrator               = steep
 

--- a/mdpow/templates/em_opls.mdp
+++ b/mdpow/templates/em_opls.mdp
@@ -1,8 +1,8 @@
 ; Gromacs mdp file
-; Template for energy minimization with OPLS-AA (part of POW)
+; Template for energy minimization with OPLS-AA (part of MDPOW)
 
 include                  = 
-define                   = -DFLEXIBLE
+; define                   = -DFLEXIBLE
 
 integrator               = steep
 


### PR DESCRIPTION
Removed the -DFLEXIBLE line in the `em_opls.mdp` template file
Changed POW into MDPOW in the `em_opls.mdp` file

Fix #117 