### PR TITLE
apply cfg mdrun.maxthreads also to mdpow.run() pipeline

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,8 @@ orbeckst, VOD555
   found. Either supply the name of the right checkpoint file or do not use
   -append": mdpow.run.runMD_or_exit() does not anymore add -append to GROMACS
   invocation (#128)
+* Configuration setting mdrun.maxthreads now also applies to energy
+  minimization with mdpow-equilibrium.py/mdpow.run() (#119)
 
 
 2017-05-02    0.6.1

--- a/mdpow/run.py
+++ b/mdpow/run.py
@@ -220,7 +220,7 @@ def equilibrium_simulation(cfg, solvent, **kwargs):
     if S.journal.has_not_completed("energy_minimize"):
         maxwarn = cfg.getint("setup", "maxwarn") or None
         prm = cfg.get("setup", "prm") or None
-        maxthreads = cfg.get('mdrun', 'maxthreads') or None,
+        maxthreads = cfg.get('mdrun', 'maxthreads') or None
         S.topology(itp=cfg.getpath("setup", "itp"), prm=prm)
         S.solvate(struct=cfg.getpath("setup", "structure"),
                   bt=cfg.get("setup", "boxtype"),

--- a/mdpow/run.py
+++ b/mdpow/run.py
@@ -220,11 +220,12 @@ def equilibrium_simulation(cfg, solvent, **kwargs):
     if S.journal.has_not_completed("energy_minimize"):
         maxwarn = cfg.getint("setup", "maxwarn") or None
         prm = cfg.get("setup", "prm") or None
+        maxthreads = cfg.get('mdrun', 'maxthreads') or None,
         S.topology(itp=cfg.getpath("setup", "itp"), prm=prm)
         S.solvate(struct=cfg.getpath("setup", "structure"),
                   bt=cfg.get("setup", "boxtype"),
                   maxwarn=maxwarn)
-        S.energy_minimize(maxwarn=maxwarn)
+        S.energy_minimize(maxwarn=maxwarn, mdrun_args={'nt': maxthreads})
         checkpoint('energy_minize', S, savefilename)
     else:
         logger.info("Fast-forwarding: setup + energy_minimize done")


### PR DESCRIPTION
- fix issue #119
- helps with #126
- NOTE: -nt maxthreads is propagated to gromacs.setup.energy_minimization()
  which might fail with minimizers that are not parallelized. NOT TESTED.