### PR TITLE
Fix `SI` input in `mdpow-pow`

### DIFF
--- a/mdpow/fep.py
+++ b/mdpow/fep.py
@@ -1020,7 +1020,7 @@ class Gsolv(Journalled):
             for l in lambdas:
                 xvg_file = self.dgdl_xvg(self.wdir(component, l))
                 xvg_df = extract(xvg_file, T=self.Temperature).iloc[start:stop:stride]
-                if (SI):
+                if SI:
                     logger.info("Perform statistical inefficiency analysis.")
                     ts = _extract_dataframe(xvg_file).iloc[start:stop:stride]
                     ts = pd.DataFrame({'time': ts.iloc[:,0], 'dhdl': ts.iloc[:,1]})
@@ -1350,9 +1350,9 @@ def p_transfer(G1, G2, **kwargs):
         if not hasattr(G, 'stop'):
             G.stop = kwargs.pop('stop', None)
         if not hasattr(G, 'SI'):
-            kwargs['SI'] = kwargs.pop('SI', False)
+            kwargs.setdefault('SI', False)
         else:
-            kwargs['SI'] = kwargs.pop('SI', G.SI)
+            kwargs.setdefault('SI', G.SI)
 
         # for this version. use the method given instead of the one in the input cfg file
         G.method = kwargs.pop('method', 'TI')

--- a/mdpow/fep.py
+++ b/mdpow/fep.py
@@ -1321,6 +1321,7 @@ def p_transfer(G1, G2, **kwargs):
            or ``mdpow`` if you want the default TI method.
        *method*
            Use `TI`, `BAR` or `MBAR` method in `alchemlyb`, or `TI` in `mdpow`.
+
     :Returns: (transfer free energy, log10 of the water-octanol partition coefficient = log Pow)
 
     """
@@ -1336,6 +1337,13 @@ def p_transfer(G1, G2, **kwargs):
     logger.info("[%s] transfer free energy %s --> %s calculation",
                 G1.molecule, G1.solvent_type, G2.solvent_type)
     for G in (G1, G2):
+        # for fep files generated with old code which doesn't have these attributes
+        if not hasattr(G, 'start'):
+            G.start = 0
+        if not hasattr(G, 'stop'):
+            G.start = None
+        if not hasattr(G, 'SI'):
+            G.SI = False
         if kwargs['force']:
             if estimator == 'mdpow':
                 G.analyze(**kwargs)
@@ -1393,6 +1401,18 @@ def pOW(G1, G2, **kwargs):
            force rereading of data files even if some data were already stored [False]
        *stride*
            analyze every *stride*-th datapoint in the dV/dlambda files
+       *start*
+           Start frame of data analyzed in every fep window.
+       *stop*
+           Stop frame of data analyzed in every fep window.
+       *SI*
+           Set to ``True`` if you want to perform statistical inefficiency
+           to preprocess the data.
+       *estimator*
+           Set to ``alchemlyb`` if you want to use alchemlyb estimators,
+           or ``mdpow`` if you want the default TI method.
+       *method*
+           Use `TI`, `BAR` or `MBAR` method in `alchemlyb`, or `TI` in `mdpow`.
 
     :Returns: (transfer free energy, log10 of the octanol/water partition coefficient = log Pow)
     """
@@ -1426,6 +1446,18 @@ def pCW(G1, G2, **kwargs):
            force rereading of data files even if some data were already stored [False]
        *stride*
            analyze every *stride*-th datapoint in the dV/dlambda files
+       *start*
+           Start frame of data analyzed in every fep window.
+       *stop*
+           Stop frame of data analyzed in every fep window.
+       *SI*
+           Set to ``True`` if you want to perform statistical inefficiency
+           to preprocess the data.
+       *estimator*
+           Set to ``alchemlyb`` if you want to use alchemlyb estimators,
+           or ``mdpow`` if you want the default TI method.
+       *method*
+           Use `TI`, `BAR` or `MBAR` method in `alchemlyb`, or `TI` in `mdpow`.
 
     :Returns: (transfer free energy, log10 of the cyclohexane/water partition coefficient = log Pcw)
     """

--- a/mdpow/fep.py
+++ b/mdpow/fep.py
@@ -1339,11 +1339,11 @@ def p_transfer(G1, G2, **kwargs):
     for G in (G1, G2):
         # for fep files generated with old code which doesn't have these attributes
         if not hasattr(G, 'start'):
-            G.start = 0
+            G.start = kwargs.pop('start', 0)
         if not hasattr(G, 'stop'):
-            G.start = None
+            G.start = kwargs.pop('stop', None)
         if not hasattr(G, 'SI'):
-            G.SI = False
+            G.SI = kwargs.pop('SI', False)
         if kwargs['force']:
             if estimator == 'mdpow':
                 G.analyze(**kwargs)

--- a/mdpow/fep.py
+++ b/mdpow/fep.py
@@ -1003,7 +1003,7 @@ class Gsolv(Journalled):
         self.logger_DeltaA0()
         return self.results.DeltaA.Gibbs
 
-    def collect_alchemlyb(self, start=0, stop=None, stride=None, autosave=True, autocompress=True):
+    def collect_alchemlyb(self, SI=False, start=0, stop=None, stride=None, autosave=True, autocompress=True):
         extract = self.estimators[self.method]['extract']
 
         if autocompress:
@@ -1017,7 +1017,7 @@ class Gsolv(Journalled):
             for l in lambdas:
                 xvg_file = self.dgdl_xvg(self.wdir(component, l))
                 xvg_df = extract(xvg_file, T=self.Temperature).iloc[start:stop:stride]
-                if self.SI:
+                if (self.SI or SI):
                     ts = _extract_dataframe(xvg_file).iloc[start:stop:stride]
                     ts = pd.DataFrame({'time': ts.iloc[:,0], 'dhdl': ts.iloc[:,1]})
                     ts = ts.set_index('time')
@@ -1028,7 +1028,7 @@ class Gsolv(Journalled):
         if autosave:
             self.save()
 
-    def analyze_alchemlyb(self, start=0, stop=None, stride=None, force=False, autosave=True):
+    def analyze_alchemlyb(self, SI=False, start=0, stop=None, stride=None, force=False, autosave=True):
         stride = stride or self.stride
         start = start or self.start
         stop = stop or self.stop
@@ -1042,11 +1042,11 @@ class Gsolv(Journalled):
 
         if force or not self.has_dVdl():
             try:
-                self.collect_alchemlyb(start, stop, stride, autosave=False)
+                self.collect_alchemlyb(SI, start, stop, stride, autosave=False)
             except IOError as err:
                 if err.errno == errno.ENOENT:
                     self.convert_edr()
-                    self.collect_alchemlyb(start, stop, stride, autosave=False)
+                    self.collect_alchemlyb(SI, start, stop, stride, autosave=False)
                 else:
                     logger.exception()
                     raise

--- a/mdpow/fep.py
+++ b/mdpow/fep.py
@@ -1020,7 +1020,8 @@ class Gsolv(Journalled):
             for l in lambdas:
                 xvg_file = self.dgdl_xvg(self.wdir(component, l))
                 xvg_df = extract(xvg_file, T=self.Temperature).iloc[start:stop:stride]
-                if (self.SI or SI):
+                if (SI):
+                    logger.info("Perform statistical inefficiency analysis.")
                     ts = _extract_dataframe(xvg_file).iloc[start:stop:stride]
                     ts = pd.DataFrame({'time': ts.iloc[:,0], 'dhdl': ts.iloc[:,1]})
                     ts = ts.set_index('time')
@@ -1349,7 +1350,9 @@ def p_transfer(G1, G2, **kwargs):
         if not hasattr(G, 'stop'):
             G.stop = kwargs.pop('stop', None)
         if not hasattr(G, 'SI'):
-            G.SI = kwargs.pop('SI', False)
+            kwargs['SI'] = kwargs.pop('SI', False)
+        else:
+            kwargs['SI'] = kwargs.pop('SI', G.SI)
 
         # for this version. use the method given instead of the one in the input cfg file
         G.method = kwargs.pop('method', 'TI')

--- a/mdpow/fep.py
+++ b/mdpow/fep.py
@@ -773,9 +773,12 @@ class Gsolv(Journalled):
             tpr_files = [self.dgdl_tpr(self.wdir(component, l)) for l in lambdas]
             for tpr, edr in zip(tpr_files, edr_files):
                 dirct = os.path.abspath(os.path.dirname(tpr))
-                total_edr = self.dgdl_total_edr(dirct)
-                logger.info("  {0} --> {1}".format('edrs', total_edr))
-                gromacs.eneconv(f=edr, o=total_edr)
+                if len(edr) == 1:
+                    total_edr = edr[0]
+                else:
+                    total_edr = self.dgdl_total_edr(dirct)
+                    logger.info("  {0} --> {1}".format('edrs', total_edr))
+                    gromacs.eneconv(f=edr, o=total_edr)
                 xvgfile = os.path.join(dirct, self.deffnm + ".xvg")  # hack
                 logger.info("  {0} --> {1}".format(total_edr, xvgfile))
                 gromacs.g_energy(s=tpr, f=total_edr, odh=xvgfile)

--- a/mdpow/fep.py
+++ b/mdpow/fep.py
@@ -1328,7 +1328,10 @@ def p_transfer(G1, G2, **kwargs):
 
     kwargs.setdefault('force', False)
     estimator = kwargs.pop('estimator', 'mdpow')
-
+    if not estimator in ('mdpow', 'alchemlyb'):
+        errmsg = "estimator = %r is not supported, must be 'mdpow' or 'alchemlyb'" % estimator
+        logger.error(errmsg)
+        raise ValueError(errmsg)
     if G1.molecule != G2.molecule:
         raise ValueError("The two simulations were done for different molecules.")
     if G1.Temperature != G2.Temperature:
@@ -1341,14 +1344,22 @@ def p_transfer(G1, G2, **kwargs):
         if not hasattr(G, 'start'):
             G.start = kwargs.pop('start', 0)
         if not hasattr(G, 'stop'):
-            G.start = kwargs.pop('stop', None)
+            G.stop = kwargs.pop('stop', None)
         if not hasattr(G, 'SI'):
             G.SI = kwargs.pop('SI', False)
+
+        # for this version. use the method given instead of the one in the input cfg file
+        G.method = kwargs.pop('method', 'TI')
         if kwargs['force']:
             if estimator == 'mdpow':
                 G.analyze(**kwargs)
+                if G.method != "TI":
+                    errmsg = "Method %s is not implemented in MDPOW, use estimator='alchemlyb'" % G.method
+                    logger.error(errmsg)
+                    raise ValueError(errmsg)
             elif estimator == 'alchemlyb':
                 G.analyze_alchemlyb(**kwargs)
+
         try:
             G.results.DeltaA.Gibbs
             G.logger_DeltaA0()

--- a/mdpow/tests/test_analysis_alchemlyb.py
+++ b/mdpow/tests/test_analysis_alchemlyb.py
@@ -109,13 +109,12 @@ class TestAnalyze(object):
 
     def test_SI(self, fep_benzene_directory):
         G = self.get_Gsolv(fep_benzene_directory)
-        G.SI = True
         G.method = 'TI'
         G.start = 0
         G.stop = None
         G.convert_edr()
         try:
-            G.analyze_alchemlyb(force=True, autosave=False)
+            G.analyze_alchemlyb(force=True, SI=True, autosave=False)
         except IOError as err:
             raise AssertionError("Failed to convert edr to xvg: {0}: {1}".format(
                 err.strerror, err.filename))
@@ -129,7 +128,6 @@ class TestAnalyze(object):
 
     def test_start_stop_stride(self, fep_benzene_directory):
         G = self.get_Gsolv(fep_benzene_directory)
-        G.SI = False
         G.method = 'TI'
         G.start = 10
         G.stride = 2

--- a/scripts/mdpow-pow
+++ b/scripts/mdpow-pow
@@ -98,7 +98,10 @@ def run_pow(directory, **kwargs):
 
     gwat, goct = load_gsolv(directory, permissive=kwargs.pop('permissive',False),)
     transferFE, logPow = mdpow.fep.pOW(goct, gwat, stride=kwargs.pop('stride', None),
-                                       force=kwargs.pop('force', False))
+                                       start=kwargs.pop('start', 0), stop=kwargs.pop('stop', None),
+                                       force=kwargs.pop('force', False), SI=kwargs.pop('SI', False),
+                                       estimator=kwargs.pop('estimator', 'mdpow'),
+                                       method=kwargs.pop('method', 'TI'))
 
     if datstat(gwat) == 'BAD' or datstat(goct) == 'BAD':
             logger.warning("Possible file corruption: water:%s, octanol:%s",
@@ -124,6 +127,8 @@ def run_pow(directory, **kwargs):
             logger.info("Wrote solvation energy terms to %(energyfile)r", kwargs)
 
     plotfile = kwargs.get('plotfile', None)
+    if estimator = 'alchemlyb':
+        plotfile = False
     if plotfile:
         if plotfile == 'auto':
             plotfile = auto_plotfile(directory, gwat)
@@ -192,6 +197,10 @@ if __name__ == "__main__":
     parser.add_option('-e', '--energies', dest="energyfile",
                       help="append solvation free energies to FILE [%default]",
                       metavar="FILE")
+    parser.add_option('--estimator', dest="estimator", default='mdpow'
+                      help="choose the estimator to be used, alchemlyb or mdpow estimators")
+    parser.add_option('--method', dest="method", default='TI'
+                      help="choose the method to calculate free energy",)
     parser.add_option('--force', dest='force',
                       action="store_true",
                       help="force rereading all data [%default]")
@@ -200,6 +209,10 @@ if __name__ == "__main__":
                       "Using a number larger than 1 can significantly reduce memory usage "
                       "with little impact on the precision of the final output. [%default]",
                       metavar="N")
+    parser.add_option('--start', dest="start", type='int',
+                      help="Start point for the data used from the original dV/dlambda data. ")
+    parser.add_option('--stop', dest="stop", type='int',
+                      help="Stop point for the data used from the original dV/dlambda data.",)
     parser.add_option('--ignore-corrupted', dest="permissive",
                       action="store_true",
                       help="skip lines in the md.xvg files that cannot be parsed. "
@@ -230,7 +243,9 @@ if __name__ == "__main__":
             run_pow(directory, plotfile=opts.plotfile,
                     outfile=realpath_or_none(opts.outfile),
                     energyfile=realpath_or_none(opts.energyfile),
-                    force=opts.force, stride=opts.stride, permissive=opts.permissive)
+                    force=opts.force, stride=opts.stride, start=opts.start,
+                    stop=opts.stop, estimator=opts.estimator,
+                    method=opts.method, permissive=opts.permissive)
         except (OSError, IOError), err:
             logger.error("Running analysis in directory %r failed: %s", directory, str(err))
         except Exception, err:

--- a/scripts/mdpow-pow
+++ b/scripts/mdpow-pow
@@ -100,7 +100,7 @@ def run_pow(directory, **kwargs):
     transferFE, logPow = mdpow.fep.pOW(goct, gwat, stride=kwargs.pop('stride', None),
                                        start=kwargs.pop('start', 0), stop=kwargs.pop('stop', None),
                                        force=kwargs.pop('force', False), SI=kwargs.pop('SI', False),
-                                       estimator=kwargs.pop('estimator', 'mdpow'),
+                                       estimator=kwargs.get('estimator', 'mdpow'),
                                        method=kwargs.pop('method', 'TI'))
 
     if datstat(gwat) == 'BAD' or datstat(goct) == 'BAD':

--- a/scripts/mdpow-pow
+++ b/scripts/mdpow-pow
@@ -96,11 +96,12 @@ def run_pow(directory, **kwargs):
     def datstat(g):
         return _datastatus[g.contains_corrupted_xvgs()]
 
+    estimator=kwargs.pop('estimator', 'mdpow')
     gwat, goct = load_gsolv(directory, permissive=kwargs.pop('permissive',False),)
     transferFE, logPow = mdpow.fep.pOW(goct, gwat, stride=kwargs.pop('stride', None),
                                        start=kwargs.pop('start', 0), stop=kwargs.pop('stop', None),
                                        force=kwargs.pop('force', False), SI=kwargs.pop('SI', False),
-                                       estimator=kwargs.get('estimator', 'mdpow'),
+                                       estimator=estimator,
                                        method=kwargs.pop('method', 'TI'))
 
     if datstat(gwat) == 'BAD' or datstat(goct) == 'BAD':

--- a/scripts/mdpow-pow
+++ b/scripts/mdpow-pow
@@ -127,7 +127,7 @@ def run_pow(directory, **kwargs):
             logger.info("Wrote solvation energy terms to %(energyfile)r", kwargs)
 
     plotfile = kwargs.get('plotfile', None)
-    if estimator = 'alchemlyb':
+    if estimator == 'alchemlyb':
         plotfile = False
     if plotfile:
         if plotfile == 'auto':

--- a/scripts/mdpow-pow
+++ b/scripts/mdpow-pow
@@ -197,7 +197,7 @@ if __name__ == "__main__":
     parser.add_option('-e', '--energies', dest="energyfile",
                       help="append solvation free energies to FILE [%default]",
                       metavar="FILE")
-    parser.add_option('--estimator', dest="estimator", default='mdpow'
+    parser.add_option('--estimator', dest="estimator", default='mdpow',
                       help="choose the estimator to be used, alchemlyb or mdpow estimators")
     parser.add_option('--method', dest="method", default='TI'
                       help="choose the method to calculate free energy",)

--- a/scripts/mdpow-pow
+++ b/scripts/mdpow-pow
@@ -204,6 +204,9 @@ if __name__ == "__main__":
     parser.add_option('--force', dest='force',
                       action="store_true",
                       help="force rereading all data [%default]")
+    parser.add_option('--SI', dest='SI',
+                      action="store_true",
+                      help="Apply statistical inefficiency analysis")
     parser.add_option('-s', '--stride', dest="stride", type='int',
                       help="Use every N-th datapoint from the original dV/dlambda data. "
                       "Using a number larger than 1 can significantly reduce memory usage "
@@ -245,7 +248,7 @@ if __name__ == "__main__":
                     energyfile=realpath_or_none(opts.energyfile),
                     force=opts.force, stride=opts.stride, start=opts.start,
                     stop=opts.stop, estimator=opts.estimator,
-                    method=opts.method, permissive=opts.permissive)
+                    method=opts.method, permissive=opts.permissive, SI=opts.SI)
         except (OSError, IOError), err:
             logger.error("Running analysis in directory %r failed: %s", directory, str(err))
         except Exception, err:

--- a/scripts/mdpow-pow
+++ b/scripts/mdpow-pow
@@ -199,7 +199,7 @@ if __name__ == "__main__":
                       metavar="FILE")
     parser.add_option('--estimator', dest="estimator", default='mdpow',
                       help="choose the estimator to be used, alchemlyb or mdpow estimators")
-    parser.add_option('--method', dest="method", default='TI'
+    parser.add_option('--method', dest="method", default='TI',
                       help="choose the method to calculate free energy",)
     parser.add_option('--force', dest='force',
                       action="store_true",


### PR DESCRIPTION
Fix #136 
-Don't save `SI` attribute to the pickle file.
-Deside whehter to perform statistical inefficiency analysis based `SI` only, not based on both `SI` and `self.SI`