### PR TITLE
Add ensemble_wrapper decorator function

### DIFF
--- a/doc/sphinx/source/analysis/ensemble.txt
+++ b/doc/sphinx/source/analysis/ensemble.txt
@@ -44,4 +44,8 @@ object when the :meth:`~mdpow.analysis.ensemble.EnsembleAtomGroup.ensemble` is r
 .. autoclass:: mdpow.analysis.ensemble.EnsembleAtomGroup
     :members:
 
-.. autodoc:: mdpow.analysis.ensemble_wrapper
+
+ensemble_wrapper Decorator
+__________________________
+
+.. automethod:: mdpow.analysis.ensemble_wrapper

--- a/doc/sphinx/source/analysis/ensemble.txt
+++ b/doc/sphinx/source/analysis/ensemble.txt
@@ -43,3 +43,5 @@ object when the :meth:`~mdpow.analysis.ensemble.EnsembleAtomGroup.ensemble` is r
 
 .. autoclass:: mdpow.analysis.ensemble.EnsembleAtomGroup
     :members:
+
+.. autodoc:: mdpow.analysis.ensemble_wrapper

--- a/doc/sphinx/source/analysis/ensemble.txt
+++ b/doc/sphinx/source/analysis/ensemble.txt
@@ -48,4 +48,4 @@ object when the :meth:`~mdpow.analysis.ensemble.EnsembleAtomGroup.ensemble` is r
 ensemble_wrapper Decorator
 __________________________
 
-.. automethod:: mdpow.analysis.ensemble_wrapper
+.. autofunction:: mdpow.analysis.ensemble_wrapper

--- a/mdpow/analysis/ensemble.py
+++ b/mdpow/analysis/ensemble.py
@@ -571,11 +571,16 @@ def ensemble_wrapper(cls):
             # Defined separately so user can modify behavior
             self._results_dict[self._key] = self._SystemRun.results
 
+        def _conclude_ensemble(self):
+            self.results = self._results_dict
+
         def run(self, start=0, stop=0, step=1):
             self._prepare_ensemble()
             for self._key in self._ensemble.keys():
                 self._SystemRun = self._Analysis(self._ensemble[self._key], *self._args, **self._kwargs)
                 self._SystemRun.run(start=start, step=step, stop=stop)
                 self._conclude_system()
+            self._conclude_ensemble()
+            return self
 
     return EnsembleWrapper

--- a/mdpow/analysis/ensemble.py
+++ b/mdpow/analysis/ensemble.py
@@ -553,8 +553,19 @@ class EnsembleAnalysis(object):
 
 
 def ensemble_wrapper(cls):
-    """ A decorator for :class:`mdanalysis.analysis.base.AnalysisBase` based classes modifying them to
-    accept an ensemble.
+    """A decorator for :class:`MDAnalysis.Universe <MDAnalysis.analysis.base.AnalysisBase>` subclasses modifying
+    them to accept an :class:`~mdpow.analysis.ensemble.Ensemble` or
+    :class:`~mdpow.analysis.ensemble.EnsembleAtomGroup`.
+
+    .. rubric:: Example Analysis
+
+        @ensemble_wrapper
+        class Example(AnalysisBase):
+            pass
+
+        Ens = Ensemble(dirname='mol_dir)
+        ExRun = Example(Ens)
+
     """
     class EnsembleWrapper:
         def __init__(self, ensemble: Union[Ensemble, EnsembleAtomGroup], *args, **kwargs):

--- a/mdpow/tests/test_ensemble.py
+++ b/mdpow/tests/test_ensemble.py
@@ -187,4 +187,4 @@ class TestEnsemble(object):
         Sim = Ensemble(dirname=self.tmpdir.name, solvents=['water'])
         SolvCount = EnsembleTest(Sim).run(stop=10)
         assert isinstance(SolvCount, EnsembleTest)
-
+        assert SolvCount.results[('water', 'VDW', '0000')] == ([42] * 10)

--- a/mdpow/tests/test_ensemble.py
+++ b/mdpow/tests/test_ensemble.py
@@ -163,7 +163,7 @@ class TestEnsemble(object):
         with pytest.raises(ValueError):
             dh_run = DihedralAnalysis([dh1, dh2, dh4, dh3]).run(start=0, stop=4, step=1)
 
-    def test_ensemble_wrapper(self):
+    def test_ensemble_wrapper1(self):
 
         class BaseTest(AnalysisBase):
             def __init__(self, system: mda.Universe):
@@ -181,8 +181,10 @@ class TestEnsemble(object):
                 self.results = self._res_arr
 
         @ensemble_wrapper
-        class EnsembleBaseTest(BaseTest):
+        class EnsembleTest(BaseTest):
             pass
 
         Sim = Ensemble(dirname=self.tmpdir.name, solvents=['water'])
-        SolvCount = EnsembleBaseTest(Sim).run(stop=10)
+        SolvCount = EnsembleTest(Sim).run(stop=10)
+        assert isinstance(SolvCount, EnsembleTest)
+


### PR DESCRIPTION
# ensemble_wrapper decorator
To simplify the process of extending AnalysisBase sub-classes to  Ensembles I wrote a class decorator function. 

Example use:
```python 
        class BaseTest(AnalysisBase):
            def __init__(self, system: mda.Universe):
                super(BaseTest, self).__init__(system.trajectory)
                self.system = system

            def _prepare(self):
                self._res_arr = []

            def _single_frame(self):
                self._res_arr.append(len(self.system.select_atoms('not resname SOL')))
                assert self._res_arr[-1] == 42

            def _conclude(self):
                self.results = self._res_arr

        @ensemble_wrapper
        class EnsembleBaseTest(BaseTest):
            pass

        Sim = Ensemble(dirname=self.tmpdir.name, solvents=['water'])
        SolvCount = EnsembleBaseTest(Sim).run(stop=10)
```
It just adds new `__init__`, `_prepare_ensemble`. `_conclude_system`, `_conclude_ensemble`, and `run` methods that run the base class and collect the results. The prepare and concluded are defined so that the user can modify the data processing of results.

### TODO
- [ ] Write more robust tests