### PR TITLE
changed dihedral atom group selection strings in test_dihedral.py 

### DIFF
--- a/mdpow/tests/test_dihedral.py
+++ b/mdpow/tests/test_dihedral.py
@@ -37,7 +37,7 @@ class TestDihedral(object):
         self.tmpdir.dissolve()
 
     def test_dataframe(self):
-        dh1 = self.Ens.select_atoms('name C4 or name C17 or name S2 or name N3')
+        dh1 = self.Ens.select_atoms('name C4', 'name C17', 'name S2', 'name N3')
         dh_run = DihedralAnalysis([dh1]).run(start=0, stop=4, step=1)
 
         results = dh_run.results
@@ -49,13 +49,13 @@ class TestDihedral(object):
             assert i == 'Coulomb'
 
     def test_selection_error(self):
-        dh1 = self.Ens.select_atoms('name C17 or name S2 or name N3')
+        dh1 = self.Ens.select_atoms('name C17', 'name S2', 'name N3')
         with pytest.raises(SelectionError):
             dh_run = DihedralAnalysis([dh1]).run(start=0, stop=4, step=1)
 
     def test_results_recursive1(self):
-        dh1 = self.Ens.select_atoms('name C11 or name C10 or name C9 or name C4')
-        dh2 = self.Ens.select_atoms('name C11 or name C10 or name C9 or name C4')
+        dh1 = self.Ens.select_atoms('name C11', 'name C10', 'name C9', 'name C4')
+        dh2 = self.Ens.select_atoms('name C11', 'name C10', 'name C9', 'name C4')
 
         dh_run1 = DihedralAnalysis([dh1]).run(start=0, stop=4, step=1)
         dh_run2 = DihedralAnalysis([dh2]).run(start=0, stop=4, step=1)
@@ -64,8 +64,8 @@ class TestDihedral(object):
             assert dh_run1.results['dihedral'][i] == dh_run2.results['dihedral'][i]
 
     def test_results_recursive2(self):
-        dh1 = self.Ens.select_atoms('name C11 or name C10 or name C9 or name C4')
-        dh2 = self.Ens.select_atoms('name C8 or name C4 or name C9 or name C10')
+        dh1 = self.Ens.select_atoms('name C11', 'name C10', 'name C9', 'name C4')
+        dh2 = self.Ens.select_atoms('name C8', 'name C4', 'name C9', 'name C10')
 
         dh_run = DihedralAnalysis([dh1, dh2]).run(start=0, stop=4, step=1)
 
@@ -84,8 +84,8 @@ class TestDihedral(object):
 
     def test_ValueError_different_ensemble(self):
         other = Ensemble(dirname=self.tmpdir.name, solvents=['water'])
-        dh1 = self.Ens.select_atoms('name C11 or name C10 or name C9 or name C4')
-        dh2 = other.select_atoms('name C8 or name C4 or name C9 or name C10')
+        dh1 = self.Ens.select_atoms('name C11', 'name C10', 'name C9', 'name C4')
+        dh2 = other.select_atoms('name C8', 'name C4', 'name C9', 'name C10')
         with pytest.raises(ValueError,
                            match='Dihedral selections from different Ensembles, '):
             DihedralAnalysis([dh1, dh2])

--- a/mdpow/tests/test_dihedral.py
+++ b/mdpow/tests/test_dihedral.py
@@ -23,9 +23,9 @@ MANIFEST = RESOURCES.join("manifest.yml")
 
 class TestDihedral(object):
     DG48910_mean = -172.9849512527183
-    DG491011_mean = -3.7300197060478695
-    DG48910_var = 1490.6576365537262
-    DG491011_var = 128.3805265432388
+    DG491011_mean = 177.74725233051953
+    DG48910_var = 0.20311120667628546
+    DG491011_var = 0.006976126708773456
 
     def setup(self):
         self.tmpdir = td.TempDir()
@@ -37,13 +37,12 @@ class TestDihedral(object):
         self.tmpdir.dissolve()
 
     def test_dataframe(self):
-	#original order C4 C17 S2 N3, ask Oliver if this matters
-        dh1 = self.Ens.select_atoms('name S2', 'name N3', 'name C4', 'name C17')
+        dh1 = self.Ens.select_atoms('name C4', 'name C17', 'name S2', 'name N3')
         dh_run = DihedralAnalysis([dh1]).run(start=0, stop=4, step=1)
 
         results = dh_run.results
 
-        assert results['selection'][0] == 'S2-N3-C4-C17'
+        assert results['selection'][0] == 'C4-C17-S2-N3'
         for s in results['solvent']:
             assert s == 'water'
         for i in results['interaction'][:12]:
@@ -70,18 +69,18 @@ class TestDihedral(object):
 
         dh_run = DihedralAnalysis([dh1, dh2]).run(start=0, stop=4, step=1)
 
-        dh1_result = dh_run.results.loc[dh_run.results['selection'] == 'C4-C9-C10-C11']['dihedral']
-        dh2_result = dh_run.results.loc[dh_run.results['selection'] == 'C4-C8-C9-C10']['dihedral']
+        dh1_result = dh_run.results.loc[dh_run.results['selection'] == 'C11-C10-C9-C4']['dihedral']
+        dh2_result = dh_run.results.loc[dh_run.results['selection'] == 'C8-C4-C9-C10']['dihedral']
 
         dh1_mean = circmean(dh1_result, high=180, low=-180)
         dh2_mean = circmean(dh2_result, high=180, low=-180)
         dh1_var = circvar(dh1_result, high=180, low=-180)
         dh2_var = circvar(dh2_result, high=180, low=-180)
 
-        assert_almost_equal(self.DG48910_mean, dh1_mean, 6)
-        assert_almost_equal(self.DG48910_var, dh1_var, 6)
-        assert_almost_equal(self.DG491011_mean, dh2_mean, 6)
-        assert_almost_equal(self.DG491011_var, dh2_var, 6)
+        assert_almost_equal(dh1_mean, self.DG48910_mean, 6)
+        assert_almost_equal(dh1_var, self.DG48910_var, 6)
+        assert_almost_equal(dh2_mean, self.DG491011_mean, 6)
+        assert_almost_equal(dh2_var, self.DG491011_var, 6)
 
     def test_ValueError_different_ensemble(self):
         other = Ensemble(dirname=self.tmpdir.name, solvents=['water'])

--- a/mdpow/tests/test_dihedral.py
+++ b/mdpow/tests/test_dihedral.py
@@ -37,7 +37,8 @@ class TestDihedral(object):
         self.tmpdir.dissolve()
 
     def test_dataframe(self):
-        dh1 = self.Ens.select_atoms('name C4', 'name C17', 'name S2', 'name N3')
+	#original order C4 C17 S2 N3, ask Oliver if this matters
+        dh1 = self.Ens.select_atoms('name S2', 'name N3', 'name C4', 'name C17')
         dh_run = DihedralAnalysis([dh1]).run(start=0, stop=4, step=1)
 
         results = dh_run.results

--- a/mdpow/tests/test_dihedral.py
+++ b/mdpow/tests/test_dihedral.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 from . import tempdir as td
 
+import sys
+
 import py.path
 
 import pybol
@@ -63,6 +65,7 @@ class TestDihedral(object):
         for i in range(len(dh_run1.results['dihedral'])):
             assert dh_run1.results['dihedral'][i] == dh_run2.results['dihedral'][i]
 
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="scipy circvar gives wrong answers")
     def test_results_recursive2(self):
         dh1 = self.Ens.select_atoms('name C11', 'name C10', 'name C9', 'name C4')
         dh2 = self.Ens.select_atoms('name C8', 'name C4', 'name C9', 'name C10')


### PR DESCRIPTION
changed selection string format for dihedral atom groups:

- old format ('name *# or name *# ... ')
- new format ('name *#', 'name *#', ... )
- ensures that the atom group is not reordered alphanumerically
- the dihedral atom group will be analyzed properly in the order that is specified with this format