### PR TITLE
Use AutoMBAR instead of MBAR

### DIFF
--- a/mdpow/fep.py
+++ b/mdpow/fep.py
@@ -157,7 +157,8 @@ import numkit.timeseries
 from numkit.observables import QuantityWithError
 
 from alchemlyb.parsing.gmx import extract_dHdl, extract_u_nk
-from alchemlyb.estimators import TI, BAR, MBAR
+from alchemlyb.estimators import TI, BAR
+from alchemlyb.estimators import AutoMBAR as MBAR
 from alchemlyb.parsing.gmx import _extract_dataframe
 from pymbar.timeseries import (statisticalInefficiency,
                                subsampleCorrelatedData, )


### PR DESCRIPTION
Fix #233 

Use AutoMBAR to avoid the not converginng error in the MBAR estimator.