### PR TITLE
test on GROMACS 2022 and 2023

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,17 +32,17 @@ jobs:
       
         os: [ubuntu-latest]
         python-version: ["3.10"]
-        gromacs-version: ["4.6.5", "2018.6", "2020.6", "2021.1"]
+        gromacs-version: ["4.6.5", "2018.6", "2020.6", "2021.1", "2022.4", "2023.1"]
         include:
           - os: ubuntu-latest
             python-version: "3.8"
-            gromacs-version: "2021.1"
+            gromacs-version: "2023.1"
           - os: ubuntu-latest
             python-version: "3.9"
-            gromacs-version: "2021.1"
+            gromacs-version: "2023.1"
           - os: macos-latest
             python-version: "3.10"
-            gromacs-version: "2021.1"
+            gromacs-version: "2023.1"
 
     env:
       MPLBACKEND: agg

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,11 @@ cadeduckworth, orbeckst, VOD555
 
 Changes
 
+* added support for Python 3.10 (#202)
+* dropped testing on Python 3.6 (PR #220, #202)
+* dropped testing on Python 3.7 (minimally supported Python >= 3.8, #248)
+* support Gromacs 2022.4 and 2023.1 (#256)
+* use pymbar >= 4 and alchemlyb >= 2 (#246)
 * for ensemble.EnsembleAnalysis._single_frame() 
   changed 'pass' to 'raise NotImplementedError' (#216)
 * for ensemble.EnsembleAnalysis._single_universe() 
@@ -18,10 +23,6 @@ Changes
   and use _single_frame OR _single_universe (#216)
 * _prepare_universe and _conclude_universe removed from 
   EnsembleAnalysis.run() method, no longer needed (per comments, #199)
-* added support for Python 3.10 (#202)
-* dropped testing on Python 3.6 (PR #220, #202)
-* dropped testing on Python 3.7 (minimally supported Python >= 3.8, #248)
-* use pymbar >= 4 and alchemlyb >= 2 (#246)
 * internal log_banner() now uses logger as argument (PR #247)
 
 Enhancements

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -32,7 +32,7 @@ Make a conda environment with the latest packages for Python 3.8 or
 higher with the name *mdpow*; this installs the larger dependencies that are
 pre-requisites for MDPOW::
 
-  conda create -c conda-forge -n mdpow  numpy scipy matplotlib mdanalysis pyyaml alchemlyb pandas gromacswrapper
+  conda create -c conda-forge -n mdpow  numpy scipy matplotlib seaborn mdanalysis pyyaml alchemlyb pandas gromacswrapper rdkit
   conda activate mdpow
 
 Install MDPOW with ``pip``::

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,7 @@
 
 .. |P_ow| replace:: *P*\ :sub:`OW`
 .. |P_cw| replace:: *P*\ :sub:`CW`
+.. |P_tw| replace:: *P*\ :sub:`TW`  
 
 *MDPOW* is a python package that automates the calculation of
 solvation free energies via molecular dynamics (MD) simulations. In
@@ -14,7 +15,8 @@ coefficients. Currently implemented:
 
 - *water-octanol* partition coefficient (|P_ow|)
 - *water-cyclohexane* partition coefficient (|P_cw|)
-
+- *water-toluene* partition coefficient (|P_tw|)
+  
 Calculations are performed with the Gromacs_ MD software package
 [#GromacsWrapperNote]_. Currently, *OPLS-AA*, *CHARMM/CGENFF*, and
 *AMBER/GAFF* parameters are supported.
@@ -47,7 +49,7 @@ See `INSTALL`_ for detailed instructions. MDPOW currently supports and
 is tested with Python 3.8 to 3.10.
 
 You will also need `Gromacs`_ (currently tested with versions 4.6.5,
-2018, 2020, 2021 but 2016 and 2019 should also work).
+2018, 2020, 2021, 2022, 2023 but 2016 and 2019 should also work).
 
 
 Development version

--- a/doc/sphinx/source/index.txt
+++ b/doc/sphinx/source/index.txt
@@ -7,7 +7,7 @@
 .. |POW|  replace:: *P*\ :sub:`OW`
 .. |P_ow| replace:: *P*\ :sub:`OW`
 .. |P_cw| replace:: *P*\ :sub:`CW`
-
+.. |P_tw| replace:: *P*\ :sub:`TW`
 
 
 MDPOW documentation
@@ -19,15 +19,16 @@ MDPOW documentation
 
 **MDPOW** is a python package that automates the calculation of
 solvation free energies via molecular dynamics (MD) simulations. In
-particular, it facilitates the computation of partition coeffcients. Currently implemented:
+particular, it facilitates the computation of partition
+coeffcients. Currently implemented:
 
 - *water-octanol* partition coefficient (|P_ow|)
 - *water-cyclohexane* partition coefficient (|P_cw|)
-
-.. warning:: Development is still very much in flux and the
-             documentation is at least partially out of date. If
-             something appears unclear or just wrong, then please ask
-             questions on the `MDPOW Issue Tracker`_.
+- *water-toluene* partition coefficient (|P_tw|)
+  
+The package is being actively developed and incorporates recent ideas
+and advances. If something appears unclear or just wrong, then please
+ask questions on the `MDPOW Issue Tracker`_.
 
 .. _`MDPOW Issue Tracker`: https://github.com/Becksteinlab/mdpow/issues
 
@@ -44,6 +45,8 @@ software package [#GromacsWrapperFramework]_. MDPOW is tested with
 * Gromacs 2018.6
 * Gromacs 2020.6
 * Gromacs 2021.1
+* Gromacs 2022.4 
+* Gromacs 2023.1 
 
 but versions 5.x, 2016.x, and 2019.x should also work.
 It should be possible to use any of these Gromacs versions without


### PR DESCRIPTION
- add conda-forge GROMACS 2022 and 2023 to CI
- update README and INSTALL
- update docs (supported versions of GROMACS)
- update CHANGES