### PR TITLE
auto-deploy GHA workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,57 @@
+name: Build and upload to PyPi
+
+on:
+  push:
+    tags:
+      - "*"
+  release:
+    types:
+      - published
+
+jobs:
+  test_pypi_push:
+    environment:
+      name: TestPyPi
+      url: https://test.pypi.org/p/MDPOW
+    permissions:
+      id-token: write
+    if: |
+      github.repository == 'Becksteinlab/MDPOW' &&
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+    name: "TestPyPi: Build and upload pure Python wheels"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: testpypi_deploy
+        uses: MDAnalysis/pypi-deployment@main
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        with:
+          test_submission: true
+          package_name: 'MDPOW'
+          module_name: 'mdpow'
+          tests: false
+          
+  pypi_push:
+    environment:
+      name: PyPi
+      url: https://pypi.org/p/MDPOW
+    permissions:
+      id-token: write
+    if: |
+      github.repository == 'Becksteinlab/MDPOW' &&
+      (github.event_name == 'release' && github.event.action == 'published')
+    name: "PyPi: Build and upload pure Python wheels"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: pypi_deploy
+        uses: MDAnalysis/pypi-deployment@main
+        if: github.event_name == 'release' && github.event.action == 'published'
+        with:        
+          package_name: 'MDPOW'
+          module_name: 'gromacs'
+          tests: false


### PR DESCRIPTION
- use MDAnalysis/pypi-deployment action for automatic deployment
- external: enable trusted publishing on PyPi and TestPyPi